### PR TITLE
Add a variable allowing the user to not create the assume role policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,9 @@ module "example" {
 |------|-------------|------|---------|:--------:|
 | account\_ids | AWS account IDs that are allowed to assume the role that allows read-only access to the specified Terraform state. | `list(string)` | `[]` | no |
 | additional\_role\_tags | Tags to apply to the IAM role that allows read-only access to the specified Terraform state, in addition to the provider's default tags. | `map(string)` | `{}` | no |
-| assume\_role\_policy\_description | The description to associate with the IAM policy that allows assumption of the role that allows read-only access to the specified Terraform state.  Note that the first "%s" in this value will get replaced with the role\_name variable and the second "%s" will get replaced with the terraform\_account\_name variable. | `string` | `"Allow assumption of the %s role in the %s account."` | no |
-| assume\_role\_policy\_name | The name to assign the IAM policy that allows assumption of the role that allows read-only access to the specified Terraform state.  Note that the "%s" in this value will get replaced with the role\_name variable. | `string` | `"Assume%s"` | no |
+| assume\_role\_policy\_description | The description to associate with the IAM policy that allows assumption of the role that allows read-only access to the specified Terraform state.  Note that the first "%s" in this value will get replaced with the role\_name variable and the second "%s" will get replaced with the terraform\_account\_name variable.  Not used if create\_assume\_role is false. | `string` | `"Allow assumption of the %s role in the %s account."` | no |
+| assume\_role\_policy\_name | The name to assign the IAM policy that allows assumption of the role that allows read-only access to the specified Terraform state.  Note that the "%s" in this value will get replaced with the role\_name variable.  Not used if create\_assume\_role is false. | `string` | `"Assume%s"` | no |
+| create\_assume\_role | A boolean value indicating whether or not to create the assume role policy.  In some cases users may want to handle the role delegation in a different way. | `bool` | `true` | no |
 | iam\_usernames | The list of IAM usernames allowed to assume the role that allows read-only access to the specified Terraform state.  If not provided, defaults to allowing any user in the specified account(s).  Note that including "root" in this list will override any other usernames in the list. | `list(string)` | `["root"]` | no |
 | role\_description | The description to associate with the IAM role (as well as the corresponding policy) that allows read-only access to the specified state in the specified S3 bucket where Terraform state is stored.  Note that the first "%s" in this value will get replaced with the terraform\_state\_path variable, the second "%s" will get replaced with the terraform\_workspace variable, and the third "%s" will get replaced with the terraform\_state\_bucket\_name variable. | `string` | `"Allows read-only access to the Terraform state at '%s' for the '%s' workspace(s) in the %s S3 bucket."` | no |
 | role\_name | The name to assign the IAM role (as well as the corresponding policy) that allows read-only access to the specified state in the S3 bucket where Terraform state is stored. | `string` | n/a | yes |
@@ -75,7 +76,7 @@ module "example" {
 
 | Name | Description |
 |------|-------------|
-| assume\_policy | The policy allowing assumption of the role that can read the specified Terraform state. |
+| assume\_policy | An array that is either empty (if no assume role policy was created) or contains a single element that is the policy allowing assumption of the role that can read the specified Terraform state. |
 | policy | The policy that can read the specified Terraform state. |
 | role | The role that can read the specified Terraform state. |
 

--- a/assume_read_terraform_state_role.tf
+++ b/assume_read_terraform_state_role.tf
@@ -13,6 +13,7 @@ data "aws_iam_policy_document" "assume_read_terraform_state_doc" {
 }
 
 resource "aws_iam_policy" "assume_read_terraform_state_role" {
+  count    = var.create_assume_role ? 1 : 0
   provider = aws.users
 
   description = local.assume_role_policy_description

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
 output "assume_policy" {
   value       = aws_iam_policy.assume_read_terraform_state_role
-  description = "The policy allowing assumption of the role that can read the specified Terraform state."
+  description = "An array that is either empty (if no assume role policy was created) or contains a single element that is the policy allowing assumption of the role that can read the specified Terraform state."
 }
 
 output "policy" {

--- a/variables.tf
+++ b/variables.tf
@@ -39,14 +39,20 @@ variable "additional_role_tags" {
 
 variable "assume_role_policy_description" {
   type        = string
-  description = "The description to associate with the IAM policy that allows assumption of the role that allows read-only access to the specified Terraform state.  Note that the first \"%s\" in this value will get replaced with the role_name variable and the second \"%s\" will get replaced with the terraform_account_name variable."
+  description = "The description to associate with the IAM policy that allows assumption of the role that allows read-only access to the specified Terraform state.  Note that the first \"%s\" in this value will get replaced with the role_name variable and the second \"%s\" will get replaced with the terraform_account_name variable.  Not used if create_assume_role is false."
   default     = "Allow assumption of the %s role in the %s account."
 }
 
 variable "assume_role_policy_name" {
   type        = string
-  description = "The name to assign the IAM policy that allows assumption of the role that allows read-only access to the specified Terraform state.  Note that the \"%s\" in this value will get replaced with the role_name variable."
+  description = "The name to assign the IAM policy that allows assumption of the role that allows read-only access to the specified Terraform state.  Note that the \"%s\" in this value will get replaced with the role_name variable.  Not used if create_assume_role is false."
   default     = "Assume%s"
+}
+
+variable "create_assume_role" {
+  type        = bool
+  description = "A boolean value indicating whether or not to create the assume role policy.  In some cases users may want to handle the role delegation in a different way."
+  default     = true
 }
 
 variable "iam_usernames" {


### PR DESCRIPTION
## 🗣 Description ##

The variable's default value of `true` ensures that the assume role policy _is_ created by default, and the `assume_role_policy_description` and `assume_role_policy_name` variable descriptions are updated to mention that they are not used if `create_assume_role` is `false`.

## 💭 Motivation and context ##

This is something that is desirable for cisagov/cool-assessment-terraform#132, since there the role we are creating to read the Terraform state is delegated to an instance role in a different way.

## 🧪 Testing ##

I used these changes successfully in cisagov/cool-assessment-terraform#132.

## ✅ Checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.
