### PR TITLE
Add permissions to interact with the DynamoDB lock table if `var.read_only` is `false`

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,10 @@ module "example" {
 
 | Name | Type |
 |------|------|
+| [aws_iam_policy.access_terraform_lock_db_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.assume_read_terraform_state_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role_policy_attachment.access_terraform_lock_db_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_policy_document.access_terraform_lock_db_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.assume_read_terraform_state_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs ##
@@ -66,6 +69,9 @@ module "example" {
 | assume\_role\_policy\_name | The name to assign the IAM policy that allows assumption of the role that allows access to the specified Terraform state.  Note that the "%s" in this value will get replaced with the role\_name variable.  Not used if create\_assume\_role is false. | `string` | `"Assume%s"` | no |
 | create\_assume\_role | A boolean value indicating whether or not to create the assume role policy.  In some cases users may want to handle the role delegation in a different way. | `bool` | `true` | no |
 | iam\_usernames | The list of IAM usernames allowed to assume the role that allows access to the specified Terraform state.  If not provided, defaults to allowing any user in the specified account(s).  Note that including "root" in this list will override any other usernames in the list. | `list(string)` | ```[ "root" ]``` | no |
+| lock\_db\_policy\_description | The description to associate with the IAM policy that allows access to the Terraform locking database.  Note that the first (and only) "%s" will get replaced with the terraform\_workspace variable.  This variable is only used if read\_only is false. | `string` | `"Allows access to the Terraform locking database for the '%s' workspace(s)."` | no |
+| lock\_db\_policy\_name | The name to assign the IAM policy that allows access to the DynamoDB state locking table.  This variable is only used if read\_only is false, and in that case it is required. | `string` | `null` | no |
+| lock\_db\_table\_arn | The ARN corresponding to the DynamoDB state locking table.  This variable is only used if read\_only is false, and in that case it is required. | `string` | `null` | no |
 | read\_only | A Boolean value indicating whether or not to make the role and policy read-only.  If false then the role and policy will allow write permissions. | `bool` | `true` | no |
 | role\_description | The description to associate with the IAM role (as well as the corresponding policy) that allows access to the specified state in the specified S3 bucket where Terraform state is stored.  Note that the first "%s" in this value will get replaced by "read-only" if read\_only is true and "read-write" otherwise, the second "%s" will get replaced with the terraform\_state\_path variable, the third "%s" will get replaced with the terraform\_workspace variable, and the fourth "%s" will get replaced with the terraform\_state\_bucket\_name variable. | `string` | `"Allows %s access to the Terraform state at '%s' for the '%s' workspace(s) in the %s S3 bucket."` | no |
 | role\_name | The name to assign the IAM role (as well as the corresponding policy) that allows access to the specified state in the S3 bucket where Terraform state is stored. | `string` | n/a | yes |

--- a/locals.tf
+++ b/locals.tf
@@ -31,4 +31,11 @@ locals {
   # var.terraform_state_bucket_name.  Otherwise just use
   # var.role_description as is.
   role_description = length(regexall(".*%s.*%s.*%s.*%s.*", var.role_description)) > 0 ? format(var.role_description, var.read_only ? "read-only" : "read-write", var.terraform_state_path, var.terraform_workspace, var.terraform_state_bucket_name) : var.role_description
+
+  # If var.lock_db_policy_description contains two instances of "%s",
+  # use format() to replace the first "%s" with
+  # var.terraform_state_path, and the second "%s" with
+  # var.terraform_workspace.  Otherwise just use
+  # var.lock_db_policy_description as is.
+  lock_db_policy_description = length(regexall(".*%s.*%s.*", var.lock_db_policy_description)) > 0 ? format(var.lock_db_policy_description, var.terraform_state_path, var.terraform_workspace) : var.lock_db_policy_description
 }

--- a/locals.tf
+++ b/locals.tf
@@ -32,10 +32,8 @@ locals {
   # var.role_description as is.
   role_description = length(regexall(".*%s.*%s.*%s.*%s.*", var.role_description)) > 0 ? format(var.role_description, var.read_only ? "read-only" : "read-write", var.terraform_state_path, var.terraform_workspace, var.terraform_state_bucket_name) : var.role_description
 
-  # If var.lock_db_policy_description contains two instances of "%s",
-  # use format() to replace the first "%s" with
-  # var.terraform_state_path, and the second "%s" with
-  # var.terraform_workspace.  Otherwise just use
-  # var.lock_db_policy_description as is.
-  lock_db_policy_description = length(regexall(".*%s.*%s.*", var.lock_db_policy_description)) > 0 ? format(var.lock_db_policy_description, var.terraform_state_path, var.terraform_workspace) : var.lock_db_policy_description
+  # If var.lock_db_policy_description contains one instance of "%s",
+  # use format() to replace the "%s" with var.terraform_workspace.
+  # Otherwise just use var.lock_db_policy_description as is.
+  lock_db_policy_description = length(regexall(".*%s.*", var.lock_db_policy_description)) > 0 ? format(var.lock_db_policy_description, var.terraform_workspace) : var.lock_db_policy_description
 }

--- a/read_terraform_state_role.tf
+++ b/read_terraform_state_role.tf
@@ -23,6 +23,8 @@ module "read_terraform_state" {
 # IAM policy document that allows sufficient access to the state
 # locking table to use that resource in a Terraform backend.
 data "aws_iam_policy_document" "access_terraform_lock_db_doc" {
+  count = var.read_only ? 0 : 1
+
   statement {
     actions = [
       "dynamodb:DeleteItem",
@@ -47,7 +49,7 @@ resource "aws_iam_policy" "access_terraform_lock_db_policy" {
 
   description = local.lock_db_policy_description
   name        = var.lock_db_policy_name
-  policy      = data.aws_iam_policy_document.access_terraform_lock_db_doc.json
+  policy      = data.aws_iam_policy_document.access_terraform_lock_db_doc[0].json
 }
 
 # Attach the IAM policy to the role

--- a/read_terraform_state_role.tf
+++ b/read_terraform_state_role.tf
@@ -37,7 +37,7 @@ data "aws_iam_policy_document" "access_terraform_lock_db_doc" {
       variable = "dynamodb:LeadingKeys"
     }
     resources = [
-      "arn:aws:dynamodb:us-east-1:210193616405:table/terraform-state-lock",
+      var.lock_db_table_arn,
     ]
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -62,8 +62,8 @@ variable "iam_usernames" {
 }
 
 variable "lock_db_policy_description" {
-  default     = "Allows access to the Terraform locking database at '%s' for the '%s' workspace(s)."
-  description = "The description to associate with the IAM policy that allows access to the Terraform locking database.  Note that the first \"%s\" will get replaced with the terraform_state_path variable, and the second \"%s\" will get replaced with the terraform_workspace variable.  This variable is only used if var.read_only is false."
+  default     = "Allows access to the Terraform locking database for the '%s' workspace(s)."
+  description = "The description to associate with the IAM policy that allows access to the Terraform locking database.  Note that the first (and only) \"%s\" will get replaced with the terraform_workspace variable.  This variable is only used if read_only is false."
   type        = string
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -61,6 +61,18 @@ variable "iam_usernames" {
   type        = list(string)
 }
 
+variable "lock_db_policy_description" {
+  default     = "Allows access to the Terraform locking database at '%s' for the '%s' workspace(s)."
+  description = "The description to associate with the IAM policy that allows access to the Terraform locking database.  Note that the first \"%s\" will get replaced with the terraform_state_path variable, and the second \"%s\" will get replaced with the terraform_workspace variable.  This variable is only used if var.read_only is false."
+  type        = string
+}
+
+variable "lock_db_policy_name" {
+  default     = ""
+  description = "The name to assign the IAM policy that allows access to the DynamoDB state locking table.  This variable is only used if var.read_only is false."
+  type        = string
+}
+
 variable "read_only" {
   default     = true
   description = "A Boolean value indicating whether or not to make the role and policy read-only.  If false then the role and policy will allow write permissions."

--- a/variables.tf
+++ b/variables.tf
@@ -74,6 +74,13 @@ variable "lock_db_policy_name" {
   type        = string
 }
 
+variable "lock_db_table_arn" {
+  default     = null
+  description = "The ARN corresponding to the DynamoDB state locking table.  This variable is only used if read_only is false, and in that case it is required."
+  nullable    = true
+  type        = string
+}
+
 variable "read_only" {
   default     = true
   description = "A Boolean value indicating whether or not to make the role and policy read-only.  If false then the role and policy will allow write permissions."

--- a/variables.tf
+++ b/variables.tf
@@ -6,16 +6,19 @@
 
 variable "role_name" {
   description = "The name to assign the IAM role (as well as the corresponding policy) that allows access to the specified state in the S3 bucket where Terraform state is stored."
+  nullable    = false
   type        = string
 }
 
 variable "terraform_state_bucket_name" {
   description = "The name of the S3 bucket where Terraform state is stored (e.g. example-terraform-state-bucket)."
+  nullable    = false
   type        = string
 }
 
 variable "terraform_state_path" {
   description = "The path to the Terraform state key(s) in the S3 bucket that the role will be allowed to access (e.g. example-terraform-project/*)."
+  nullable    = false
   type        = string
 }
 
@@ -28,42 +31,49 @@ variable "terraform_state_path" {
 variable "account_ids" {
   default     = []
   description = "AWS account IDs that are allowed to assume the role that allows access to the specified Terraform state."
+  nullable    = false
   type        = list(string)
 }
 
 variable "additional_role_tags" {
   default     = {}
   description = "Tags to apply to the IAM role that allows access to the specified Terraform state, in addition to the provider's default tags."
+  nullable    = false
   type        = map(string)
 }
 
 variable "assume_role_policy_description" {
   default     = "Allow assumption of the %s role in the %s account."
   description = "The description to associate with the IAM policy that allows assumption of the role that allows access to the specified Terraform state.  Note that the first \"%s\" in this value will get replaced with the role_name variable and the second \"%s\" will get replaced with the terraform_account_name variable.  Not used if create_assume_role is false."
+  nullable    = false
   type        = string
 }
 
 variable "assume_role_policy_name" {
   default     = "Assume%s"
   description = "The name to assign the IAM policy that allows assumption of the role that allows access to the specified Terraform state.  Note that the \"%s\" in this value will get replaced with the role_name variable.  Not used if create_assume_role is false."
+  nullable    = false
   type        = string
 }
 
 variable "create_assume_role" {
   default     = true
   description = "A boolean value indicating whether or not to create the assume role policy.  In some cases users may want to handle the role delegation in a different way."
+  nullable    = false
   type        = bool
 }
 
 variable "iam_usernames" {
   default     = ["root"]
   description = "The list of IAM usernames allowed to assume the role that allows access to the specified Terraform state.  If not provided, defaults to allowing any user in the specified account(s).  Note that including \"root\" in this list will override any other usernames in the list."
+  nullable    = false
   type        = list(string)
 }
 
 variable "lock_db_policy_description" {
   default     = "Allows access to the Terraform locking database for the '%s' workspace(s)."
   description = "The description to associate with the IAM policy that allows access to the Terraform locking database.  Note that the first (and only) \"%s\" will get replaced with the terraform_workspace variable.  This variable is only used if read_only is false."
+  nullable    = false
   type        = string
 }
 
@@ -84,23 +94,27 @@ variable "lock_db_table_arn" {
 variable "read_only" {
   default     = true
   description = "A Boolean value indicating whether or not to make the role and policy read-only.  If false then the role and policy will allow write permissions."
+  nullable    = false
   type        = bool
 }
 
 variable "role_description" {
   default     = "Allows %s access to the Terraform state at '%s' for the '%s' workspace(s) in the %s S3 bucket."
   description = "The description to associate with the IAM role (as well as the corresponding policy) that allows access to the specified state in the specified S3 bucket where Terraform state is stored.  Note that the first \"%s\" in this value will get replaced by \"read-only\" if read_only is true and \"read-write\" otherwise, the second \"%s\" will get replaced with the terraform_state_path variable, the third \"%s\" will get replaced with the terraform_workspace variable, and the fourth \"%s\" will get replaced with the terraform_state_bucket_name variable."
+  nullable    = false
   type        = string
 }
 
 variable "terraform_account_name" {
   default     = "Terraform"
   description = "The name of the account containing the S3 bucket where Terraform state is stored."
+  nullable    = false
   type        = string
 }
 
 variable "terraform_workspace" {
   default     = "*"
   description = "The name of the workspace containing the Terraform state that the role will be allowed to access.  Defaults to all workspaces ('*')."
+  nullable    = false
   type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -68,8 +68,9 @@ variable "lock_db_policy_description" {
 }
 
 variable "lock_db_policy_name" {
-  default     = ""
-  description = "The name to assign the IAM policy that allows access to the DynamoDB state locking table.  This variable is only used if var.read_only is false."
+  default     = null
+  description = "The name to assign the IAM policy that allows access to the DynamoDB state locking table.  This variable is only used if read_only is false, and in that case it is required."
+  nullable    = true
   type        = string
 }
 


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the Terraform module so that the permissions necessary to interact with the DynamoDB lock table in the Terraform backend are added if `var.read_only` is `false`.

## 💭 Motivation and context ##

If a user wants to write the Terraform state then he or she is most likely doing so via the Terraform backend.

## 🧪 Testing ##

All automated tests pass.  I also tested these changes as part of cisagov/cool-assessment-terraform#250.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.