### PR TITLE
Add variable to specify additional, read-only states to which the role should also be granted access

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ module "example" {
 | Name | Source | Version |
 |------|--------|---------|
 | read\_terraform\_state | github.com/cisagov/s3-read-role-tf-module | n/a |
+| read\_terraform\_state\_additional\_states | github.com/cisagov/s3-read-role-tf-module | n/a |
 
 ## Resources ##
 
@@ -56,6 +57,7 @@ module "example" {
 | [aws_iam_policy.access_terraform_lock_db_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.assume_read_terraform_state_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role_policy_attachment.access_terraform_lock_db_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.read_only_state_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_policy_document.access_terraform_lock_db_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.assume_read_terraform_state_doc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
@@ -64,6 +66,9 @@ module "example" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | account\_ids | AWS account IDs that are allowed to assume the role that allows access to the specified Terraform state. | `list(string)` | `[]` | no |
+| additional\_read\_only\_states | A map.  The keys are the state paths and the values are objects where only the key "workspace" is supported, and this key is required.  Together the key and value define an additional workspace-specific state to which the user should be granted read-only access.  E.g., {cool-accounts/dynamic.tfstate = {workspace = env6-staging}}. | `map(object({ workspace = string }))` | `{}` | no |
+| additional\_read\_only\_states\_role\_description | The description to associate with the IAM role (as well as the corresponding policy) that allows read-only access to any additional states in the specified S3 bucket where Terraform state is stored.  The "%s" will get replaced with the terraform\_state\_bucket\_name variable.  Note that these additional states (if any) are defined in additional\_read\_only\_states; hence, this variable is not used if additional\_read\_only\_states is an empty map. | `string` | `"Allows read-only access to additional Terraform states in the %s S3 bucket."` | no |
+| additional\_read\_only\_states\_role\_name | The name to assign the IAM role (as well as the corresponding policy) that allows access to any additional, read-only states in the S3 bucket where Terraform state is stored.  Note that these additional states (if any) are defined in additional\_read\_only\_states; hence, this variable is not used if additional\_read\_only\_states is an empty map.  If additional\_read\_only\_states is non-empty then thisd variable is required. | `string` | `null` | no |
 | additional\_role\_tags | Tags to apply to the IAM role that allows access to the specified Terraform state, in addition to the provider's default tags. | `map(string)` | `{}` | no |
 | assume\_role\_policy\_description | The description to associate with the IAM policy that allows assumption of the role that allows access to the specified Terraform state.  Note that the first "%s" in this value will get replaced with the role\_name variable and the second "%s" will get replaced with the terraform\_account\_name variable.  Not used if create\_assume\_role is false. | `string` | `"Allow assumption of the %s role in the %s account."` | no |
 | assume\_role\_policy\_name | The name to assign the IAM policy that allows assumption of the role that allows access to the specified Terraform state.  Note that the "%s" in this value will get replaced with the role\_name variable.  Not used if create\_assume\_role is false. | `string` | `"Assume%s"` | no |

--- a/locals.tf
+++ b/locals.tf
@@ -23,6 +23,16 @@ locals {
     var.terraform_workspace != "default" ? ["env:/${var.terraform_workspace}/${var.terraform_state_path}"] : [],
   )
 
+  # Create a list of additional paths in the S3 bucket that our role
+  # is allowed to read.
+  additional_bucket_paths_allowed_to_read = [for k, v in var.additional_read_only_states : concat(
+    # If the "default" workspace (or "*" for all workspaces) is specified,
+    # include the path where Terraform stores default workspace state.
+    contains(["*", "default"], v.workspace) ? [k] : [],
+    # For non-"default" workspaces, include the correct bucket path.
+    v.workspace != "default" ? ["env:/${v.workspace}/${k}"] : [],
+  )[0]]
+
   # If var.role_description contains four instances of "%s", use
   # format() to replace the first "%s" with "read-only" if read_only
   # is true and "read-write" otherwise, the second "%s" with
@@ -36,4 +46,10 @@ locals {
   # use format() to replace the "%s" with var.terraform_workspace.
   # Otherwise just use var.lock_db_policy_description as is.
   lock_db_policy_description = length(regexall(".*%s.*", var.lock_db_policy_description)) > 0 ? format(var.lock_db_policy_description, var.terraform_workspace) : var.lock_db_policy_description
+
+  # If var.additional_read_only_states_role_description contains a
+  # single instances of "%s", use format() to replace it with
+  # var.terraform_state_bucket_name.  Otherwise just use
+  # var.additional_read_only_states_role_description as is.
+  additional_read_only_states_role_description = length(regexall(".*%s.*", var.additional_read_only_states_role_description)) > 0 ? format(var.additional_read_only_states_role_description, var.terraform_state_bucket_name) : var.additional_read_only_states_role_description
 }

--- a/locals.tf
+++ b/locals.tf
@@ -14,8 +14,8 @@ locals {
   # var.assume_role_policy_name as is.
   assume_role_policy_name = length(regexall(".*%s.*", var.assume_role_policy_name)) > 0 ? format(var.assume_role_policy_name, var.role_name) : var.assume_role_policy_name
 
-  # Create a list of paths in the S3 bucket that our role is allowed to read.
-  bucket_paths_allowed_to_read = concat(
+  # Create a list of paths in the S3 bucket that our role is allowed to access.
+  bucket_paths_allowed_to_access = concat(
     # If the "default" workspace (or "*" for all workspaces) is specified,
     # include the path where Terraform stores default workspace state.
     contains(["*", "default"], var.terraform_workspace) ? [var.terraform_state_path] : [],

--- a/read_terraform_state_role.tf
+++ b/read_terraform_state_role.tf
@@ -17,7 +17,7 @@ module "read_terraform_state" {
   role_description     = local.role_description
   role_name            = var.role_name
   s3_bucket            = var.terraform_state_bucket_name
-  s3_objects           = local.bucket_paths_allowed_to_read
+  s3_objects           = local.bucket_paths_allowed_to_access
 }
 
 # IAM policy document that allows sufficient access to the state
@@ -33,7 +33,7 @@ data "aws_iam_policy_document" "access_terraform_lock_db_doc" {
     ]
     condition {
       test     = "ForAnyValue:StringEquals"
-      values   = flatten([for path in local.bucket_paths_allowed_to_read : ["${var.terraform_state_bucket_name}/${path}", "${var.terraform_state_bucket_name}/${path}-md5"]])
+      values   = flatten([for path in local.bucket_paths_allowed_to_access : ["${var.terraform_state_bucket_name}/${path}", "${var.terraform_state_bucket_name}/${path}-md5"]])
       variable = "dynamodb:LeadingKeys"
     }
     resources = [

--- a/read_terraform_state_role.tf
+++ b/read_terraform_state_role.tf
@@ -59,3 +59,30 @@ resource "aws_iam_role_policy_attachment" "access_terraform_lock_db_policy_attac
   policy_arn = aws_iam_policy.access_terraform_lock_db_policy[0].arn
   role       = module.read_terraform_state.role.name
 }
+
+module "read_terraform_state_additional_states" {
+  count = length(local.additional_bucket_paths_allowed_to_read) == 0 ? 0 : 1
+
+  source = "github.com/cisagov/s3-read-role-tf-module"
+  providers = {
+    aws = aws
+  }
+
+  account_ids          = var.account_ids
+  additional_role_tags = var.additional_role_tags
+  entity_name          = var.additional_read_only_states_role_name
+  iam_usernames        = var.iam_usernames
+  read_only            = true
+  role_description     = local.additional_read_only_states_role_description
+  role_name            = var.additional_read_only_states_role_name
+  s3_bucket            = var.terraform_state_bucket_name
+  s3_objects           = local.additional_bucket_paths_allowed_to_read
+}
+
+# Attach the additional state read-only IAM policy to the role
+resource "aws_iam_role_policy_attachment" "read_only_state_policy_attachment" {
+  count = length(local.additional_bucket_paths_allowed_to_read) == 0 ? 0 : 1
+
+  policy_arn = module.read_terraform_state_additional_states[0].policy.arn
+  role       = module.read_terraform_state.role.name
+}

--- a/variables.tf
+++ b/variables.tf
@@ -35,6 +35,27 @@ variable "account_ids" {
   type        = list(string)
 }
 
+variable "additional_read_only_states" {
+  default     = {}
+  description = "A map.  The keys are the state paths and the values are objects where only the key \"workspace\" is supported, and this key is required.  Together the key and value define an additional workspace-specific state to which the user should be granted read-only access.  E.g., {cool-accounts/dynamic.tfstate = {workspace = env6-staging}}."
+  nullable    = false
+  type        = map(object({ workspace = string }))
+}
+
+variable "additional_read_only_states_role_description" {
+  default     = "Allows read-only access to additional Terraform states in the %s S3 bucket."
+  description = "The description to associate with the IAM role (as well as the corresponding policy) that allows read-only access to any additional states in the specified S3 bucket where Terraform state is stored.  The \"%s\" will get replaced with the terraform_state_bucket_name variable.  Note that these additional states (if any) are defined in additional_read_only_states; hence, this variable is not used if additional_read_only_states is an empty map."
+  nullable    = false
+  type        = string
+}
+
+variable "additional_read_only_states_role_name" {
+  default     = null
+  description = "The name to assign the IAM role (as well as the corresponding policy) that allows access to any additional, read-only states in the S3 bucket where Terraform state is stored.  Note that these additional states (if any) are defined in additional_read_only_states; hence, this variable is not used if additional_read_only_states is an empty map.  If additional_read_only_states is non-empty then thisd variable is required."
+  nullable    = true
+  type        = string
+}
+
 variable "additional_role_tags" {
   default     = {}
   description = "Tags to apply to the IAM role that allows access to the specified Terraform state, in addition to the provider's default tags."


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds a role variable to specify additional, read-only states to which the role should also be granted access.

## 💭 Motivation and context ##

This is required to grant some assessors sufficient access to redeploy their own instances.  See cisagov/cool-assessment-terraform#250.

## 🧪 Testing ##

All automated tests pass.  This change was tested as part of cisagov/cool-assessment-terraform#250.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.