### PR TITLE
Support multi-environment usage in example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ __pycache__
 .terraform.lock.hcl
 terraform.tfstate
 terraform.tfstate.backup
+*.tfconfig
 *.tfvars

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ module "example" {
 
   account_ids = ["111111111111"]
   role_name = "ReadTerraformStateReadRoleTFModuleTerraformState"
-  terraform_state_bucket_name = "cisa-cool-terraform-state"
+  terraform_state_bucket_name = "my-terraform-state-bucket"
   terraform_state_path = "terraform-state-read-role-tf-module/examples/basic_usage/*.tfstate"
 }
 ```

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ module "example" {
 | role\_description | The description to associate with the IAM role (as well as the corresponding policy) that allows access to the specified state in the specified S3 bucket where Terraform state is stored.  Note that the first "%s" in this value will get replaced by "read-only" if read\_only is true and "read-write" otherwise, the second "%s" will get replaced with the terraform\_state\_path variable, the third "%s" will get replaced with the terraform\_workspace variable, and the fourth "%s" will get replaced with the terraform\_state\_bucket\_name variable. | `string` | `"Allows %s access to the Terraform state at '%s' for the '%s' workspace(s) in the %s S3 bucket."` | no |
 | role\_name | The name to assign the IAM role (as well as the corresponding policy) that allows access to the specified state in the S3 bucket where Terraform state is stored. | `string` | n/a | yes |
 | terraform\_account\_name | The name of the account containing the S3 bucket where Terraform state is stored. | `string` | `"Terraform"` | no |
-| terraform\_state\_bucket\_name | The name of the S3 bucket where Terraform state is stored (e.g. example-terraform-state-bucket). | `string` | n/a | yes |
+| terraform\_state\_bucket\_name | The name of the S3 bucket where Terraform state is stored (e.g. my-terraform-state-bucket). | `string` | n/a | yes |
 | terraform\_state\_path | The path to the Terraform state key(s) in the S3 bucket that the role will be allowed to access (e.g. example-terraform-project/*). | `string` | n/a | yes |
 | terraform\_workspace | The name of the workspace containing the Terraform state that the role will be allowed to access.  Defaults to all workspaces ('*'). | `string` | `"*"` | no |
 

--- a/examples/basic_usage/README.md
+++ b/examples/basic_usage/README.md
@@ -35,8 +35,8 @@ is required to initialize the Terraform backend in each environment:
   example:
 
     ```hcl
-    account_ids            = ["111111111111"]
-    terraform_state_bucket = "my-dev-terraform-state-bucket"
+    account_ids                 = ["111111111111"]
+    terraform_state_bucket_name = "my-dev-terraform-state-bucket"
     ```
 
 1. Run `terraform apply -var-file=dev.tfvars` to create the IAM role and

--- a/examples/basic_usage/README.md
+++ b/examples/basic_usage/README.md
@@ -2,18 +2,45 @@
 
 ## Usage ##
 
-To run this example, do the following:
+To run this example, do the following (the steps below use an example
+environment named "dev"; replace "dev" with the name of your environment):
 
-- Execute the `terraform init` command to initialize Terraform.
-- Create a Terraform variables file (e.g. `example.tfvars`) containing
-  the account ID(s) that are allowed to assume the Terraform role that will
-  be created:
+1. Create a backend configuration file named `dev.tfconfig` containing the name
+of the S3 bucket where "dev" environment Terraform state is stored - this file
+is required to initialize the Terraform backend in each environment:
 
-  ```hcl
-  account_ids = ["111111111111"]
-  ```
+    ```hcl
+    bucket = "my-dev-terraform-state-bucket"
+    ```
 
-- Execute the `terraform apply` command to create the IAM role and policies.
+1. Initialize the Terraform backend for the "dev" environment using your backend
+   configuration file:
+
+    ```console
+    terraform init -upgrade -backend-config=dev.tfconfig
+    ```
+
+    > [!NOTE]
+    > When performing this step for additional environments (i.e. not your first
+    > environment), use the `-reconfigure` flag:
+    >
+    > ```console
+    > terraform init -upgrade -backend-config=other-env.tfconfig -reconfigure
+    > ```
+
+1. Create a Terraform variables file named `dev.tfvars` containing the account
+  ID(s) that are allowed to assume the Terraform role that will be created and
+  the name of the S3 bucket where Terraform state is stored (this should match
+  the same bucket name as in the `dev.tfconfig` you created previously). For
+  example:
+
+    ```hcl
+    account_ids            = ["111111111111"]
+    terraform_state_bucket = "my-dev-terraform-state-bucket"
+    ```
+
+1. Run `terraform apply -var-file=dev.tfvars` to create the IAM role and
+   policies.
 
 Notes:
 
@@ -51,6 +78,7 @@ No resources.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | account\_ids | AWS account IDs that are allowed to assume the role that allows read-only access to the Terraform state for this example. | `list(string)` | n/a | yes |
+| terraform\_state\_bucket | The name of the S3 bucket where Terraform state is stored. | `string` | n/a | yes |
 
 ## Outputs ##
 

--- a/examples/basic_usage/backend.tf
+++ b/examples/basic_usage/backend.tf
@@ -1,6 +1,10 @@
 terraform {
   backend "s3" {
-    bucket         = "cisa-cool-terraform-state"
+    # Use a partial configuration to avoid hardcoding the bucket name. This
+    # allows the bucket name to be set on a per-environment basis via the
+    # -backend-config command line option or other methods.  For details, see:
+    # https://developer.hashicorp.com/terraform/language/backend#partial-configuration
+    bucket         = ""
     dynamodb_table = "terraform-state-lock"
     encrypt        = true
     key            = "terraform-state-read-role-tf-module/examples/basic_usage/terraform.tfstate"

--- a/examples/basic_usage/main.tf
+++ b/examples/basic_usage/main.tf
@@ -33,6 +33,6 @@ module "example" {
 
   account_ids                 = var.account_ids
   role_name                   = "ReadTerraformStateReadRoleTFModuleTerraformState"
-  terraform_state_bucket_name = "cisa-cool-terraform-state"
+  terraform_state_bucket_name = var.terraform_state_bucket
   terraform_state_path        = "terraform-state-read-role-tf-module/examples/basic_usage/*.tfstate"
 }

--- a/examples/basic_usage/main.tf
+++ b/examples/basic_usage/main.tf
@@ -33,6 +33,6 @@ module "example" {
 
   account_ids                 = var.account_ids
   role_name                   = "ReadTerraformStateReadRoleTFModuleTerraformState"
-  terraform_state_bucket_name = var.terraform_state_bucket
+  terraform_state_bucket_name = var.terraform_state_bucket_name
   terraform_state_path        = "terraform-state-read-role-tf-module/examples/basic_usage/*.tfstate"
 }

--- a/examples/basic_usage/variables.tf
+++ b/examples/basic_usage/variables.tf
@@ -9,7 +9,7 @@ variable "account_ids" {
   type        = list(string)
 }
 
-variable "terraform_state_bucket" {
+variable "terraform_state_bucket_name" {
   description = "The name of the S3 bucket where Terraform state is stored."
   nullable    = false
   type        = string

--- a/examples/basic_usage/variables.tf
+++ b/examples/basic_usage/variables.tf
@@ -9,6 +9,12 @@ variable "account_ids" {
   type        = list(string)
 }
 
+variable "terraform_state_bucket" {
+  description = "The name of the S3 bucket where Terraform state is stored."
+  nullable    = false
+  type        = string
+}
+
 # ------------------------------------------------------------------------------
 # OPTIONAL PARAMETERS
 #

--- a/variables.tf
+++ b/variables.tf
@@ -11,7 +11,7 @@ variable "role_name" {
 }
 
 variable "terraform_state_bucket_name" {
-  description = "The name of the S3 bucket where Terraform state is stored (e.g. example-terraform-state-bucket)."
+  description = "The name of the S3 bucket where Terraform state is stored (e.g. my-terraform-state-bucket)."
   nullable    = false
   type        = string
 }


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR updates the example code used to call `cisagov/terraform-state-read-role-tf-module` to remove a hard-coded bucket name and use a [partial backend configuration](https://developer.hashicorp.com/terraform/language/backend#partial-configuration).  The corresponding documentation is also updated to reflect the changes.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Whenever possible, we strive to remove hard-coded bucket names in our code.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I successfully applied and then destroyed the updated Terraform in `examples/basic_usage` without any problems.

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
